### PR TITLE
Add conceptual explanations and section intros to labs 2-7

### DIFF
--- a/public/02-docker-images.md
+++ b/public/02-docker-images.md
@@ -2,6 +2,8 @@
 
 ## A. Image Immutability
 
+> A core property of a Docker image: once built, the filesystem it contains is fixed. When you run a container, you get a thin **writable layer** on top of those read-only image layers — anything you write there belongs to the container, not the image. The next steps prove this by writing a file inside one container and then starting a fresh container from the same image to look for it.
+
 1. Pull an Ubuntu Linux image and connect to a shell session inside it.
 ```
 cd ~
@@ -47,7 +49,11 @@ ls
 exit
 ```
 
+> The second container started clean — `/file1` lived only in the writable layer of **testcontainer**, which was discarded when that container exited. The image itself was never modified, so any container launched from it always begins from the same state. This is what people mean when they say containers are *reproducible*.
+
 ## B. Layers and Processes
+
+> Docker images are built as a **stack of read-only layers**, each capturing the filesystem changes from one build instruction. When a container starts, Docker mounts those layers together with a writable layer on top, using a *union filesystem*. The same base layer is shared by every image and container that uses it — that's why a hundred Ubuntu containers don't consume a hundred times the disk of one.
 
 1. Explore the layers in the **hello-world** image.
 ```
@@ -82,6 +88,8 @@ docker stop singleprocesscontainer
 ```
 
 ## C. Build From an Existing Container
+
+> `docker commit` snapshots a running container's filesystem into a new image. It's useful for ad-hoc experimentation — "save what I have right now" — but it's a poor fit for production. The resulting image is opaque: there's no record of what was installed, in what order, or from what source. Dockerfiles (Section D) solve that problem by making the build steps explicit and reproducible.
 
 1. Restart the Ubuntu **testcontainer**.
 ```
@@ -124,6 +132,8 @@ docker stop testcontainerv2
 
 ## D. Building From Dockerfile
 
+> A **Dockerfile** is a text recipe for building an image. `FROM` declares the base image; `RUN` executes a command and commits the result as a new layer; `COPY` brings files from the build context into the image; `CMD` sets the default command for containers started from the image. Because each instruction creates a layer, ordering matters for **caching** — put rarely-changing instructions (package installs) above frequently-changing ones (your source code), so an edit to your code doesn't invalidate the install layer.
+
 1. Create a local directory to hold a container build configuration.
 ```
 mkdir mynginx/
@@ -164,6 +174,8 @@ docker image inspect mynginx
 ```
 
 ## E. Multi-Stage Builds
+
+> A **multi-stage build** uses multiple `FROM` instructions in one Dockerfile. Each `FROM` starts a fresh image, and you can `COPY --from=<stage>` to selectively pull artifacts out of an earlier stage. The win is that the final image ships only the compiled output, not the toolchain that built it — that shrinks the image, speeds pulls, and removes a class of attack surface (no `gcc` lying around for an intruder to misuse).
 
 1. Create a new directory to hold the configuration for a simple web app.
 ```
@@ -217,6 +229,8 @@ docker run mysimpleapp
 
 ## F. Docker Hub
 
+> A **registry** is where built images live and get distributed; Docker Hub is the default public one. Authenticating with an **access token** rather than your account password is the standard practice: tokens are scoped (e.g., read-only vs. push-and-delete), individually revocable, and don't expose the credentials you use to log into the web UI.
+
 1. Navigate to Docker Hub in your web browser.
 ```
 https://hub.docker.com
@@ -268,6 +282,8 @@ docker push $MY_DOCKER_USERNAME/mysimpleapp:0.0.1
 > Do the image layers resemble the image you pushed?
 
 ## G. Clean Up
+
+> `docker image prune` removes **dangling** images — image layers no longer referenced by a tag, usually leftovers from rebuilds. `docker system prune` goes further, removing stopped containers, unused networks, and the build cache as well. Routine cleanup keeps disk usage in check on a development machine.
 
 Run the following to clean up unused images and containers. Enter `y` if prompted.
 

--- a/public/03-docker-containers-and-volumes.md
+++ b/public/03-docker-containers-and-volumes.md
@@ -2,7 +2,7 @@
 
 ## A. Isolation
 
-> **Container isolation** means that each container has its own filesystem, process space, and network stack. Multiple containers created from the same image are completely isolated from each other by default. Let's prove this.
+> **Container isolation** means that each container has its own filesystem, process space, and network stack. Underneath, the Linux kernel provides this via **namespaces** — mount, PID, network, and others — that wall off each container's view of the system. Multiple containers created from the same image are completely isolated from each other by default. Let's prove this.
 
 1. Launch two separate containers from the same Ubuntu image.
 ```
@@ -39,7 +39,7 @@ docker exec -it container2 bash -c "cat /isolated_file.txt"
 
 ## B. Port Mapping
 
-> Docker containers by default run on networks separate from the underlying host.
+> Docker containers by default attach to a **bridge network** with addresses in the `172.x.x.x` range. Those addresses are reachable from the Docker host but not from anything outside it — fine for container-to-container traffic, but a problem the moment you want a browser or another machine to reach the service. **Port mapping** (`-p`) is the answer: Docker adds an iptables / userland-proxy rule that forwards a port on the host's interface to a port inside the container.
 
 1. Create a web service container from an NGINX image. 
 ```
@@ -97,7 +97,7 @@ docker rm webserver0
 
 ## C. Environment Variables
 
-> Docker supports environment variables that can be defined in the application code and in the Dockerfile itself. Let's practice with a simple Flask app.
+> Docker supports environment variables defined in the application code, baked into the Dockerfile, or passed in at run time. The last form is the most flexible: it follows the **12-factor app** principle of keeping configuration separate from code, so the same image can deploy to different environments by changing only the variables passed at startup. Let's practice with a simple Flask app.
 
 1. Create a directory to hold a Python web app and accompanying Dockerfile.
 ```
@@ -198,7 +198,7 @@ docker rm myenvvarapp
 
 ## D. Volumes
 
-> Docker volumes allow Docker to manage and store persistent data. They allow data to persist beyond the lifecycle of a single container, and can be even shared between containers. Docker volumes are essential for storing non-ephemeral data.
+> By default, anything written inside a container disappears when the container is removed — that writable layer is ephemeral, which is fine for most application state but disastrous for databases, caches, or user uploads. **Volumes** are how containers opt into persistence. The *named volume* used in this section is managed entirely by Docker and stored under `/var/lib/docker/volumes`; a *bind mount* (covered elsewhere) would instead reach into a specific path on the host filesystem. Volumes can also be shared between containers, which we'll demonstrate.
 
 1. Create a Docker volume to store persistent data.
 ```
@@ -382,6 +382,8 @@ docker stop onfailureapp
 ```
 docker rm onfailureapp
 ```
+
+> **`unless-stopped`** looks similar to `always` but with one important difference: it respects a manual `docker stop`. A container stopped that way stays stopped even after the Docker daemon restarts — whereas `always` would bring it back. That's the behavior the next set of steps demonstrates.
 
 17. Run a healhty app, this time with an **unless-stopped** restart policy.
 ```

--- a/public/04-docker-networking.md
+++ b/public/04-docker-networking.md
@@ -2,6 +2,8 @@
 
 ## A. Create and use a Docker network
 
+> Docker exposes several **network drivers**: `bridge` (default — isolates containers on a single host), `host` (the container shares the host's network stack), `none` (no networking at all), and `overlay` (multi-host, covered in Section B). A *custom* bridge network like the one we're about to create has one practical advantage over the built-in `bridge`: containers attached to it can resolve each other's names via Docker's embedded DNS server, not just by IP.
+
 1. Create a custom bridge network. Bridge networks provide isolated networking on a single Docker host, with automatic DNS resolution between containers.
 ```
 docker network create --driver bridge mybridgenet
@@ -35,6 +37,8 @@ echo "IP address of nginx2 is $NGINX2_IP"
 docker exec nginx1 curl http://$NGINX2_IP
 docker exec nginx2 curl http://$NGINX1_IP
 ```
+
+> Because **mybridgenet** is a custom bridge with embedded DNS, we could just as well have written `docker exec nginx1 curl http://nginx2` — the service name resolves to the right IP automatically. The default `bridge` network does not offer this; on that network you'd be stuck passing IPs around (or using the deprecated `--link` flag).
 
 6. Create a container **not** yet connected to your custom network.
 ```
@@ -78,6 +82,8 @@ docker network rm mybridgenet
 
 ## B. Expose and link containers
 
+> So far the containers we've created have only been reachable from inside Docker's networks. **Publishing a port** (`-p host:container`) is the standard way to expose a service to the host machine — and through the host to the outside world. **Container linking** (`--link`), explored second, is an older mechanism that predates user-defined networks: it injects environment variables and `/etc/hosts` entries into the linked container. It still works but has been deprecated, because user-defined bridge networks (Section A) cover the same use case more cleanly.
+
 1. Run a new NGINX container with port 80 exposed to port 8080 on localhost.
 ```
 docker run -d --name nginxpublic -p 8080:80 nginx
@@ -103,7 +109,7 @@ NGINXPUB_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}
 docker exec linkednginx curl http://$NGINXPUB_IP
 ```
 
-> Docker Swarm uses **overlay networks** to enable communication between containers running on different Docker hosts. An overlay network creates a distributed network among multiple Docker daemon hosts, abstracting away the underlying network infrastructure.
+> So far every container has lived on a single Docker host. **Overlay networks** are how containers communicate when they're spread across multiple hosts. They require a control plane that tracks which container is on which host — which is why this section starts by initializing Docker Swarm: even with a single node, swarm mode is what enables the overlay driver. (Kubernetes solves the same problem with its own CNI plugins, but the underlying primitives are similar.)
 
 
 5. Initialize Docker swarm.

--- a/public/05-docker-advanced.md
+++ b/public/05-docker-advanced.md
@@ -63,7 +63,7 @@ source ~/.bashrc
 docker context ls
 ```
 
-> Note the presence of the default (root-based) as well as rootless contexts.
+> A Docker **context** is a named connection target for the CLI — a (daemon socket, TLS config) pair that the `docker` command knows how to talk to. The listing here should show both the **default** root-based context and the new **rootless** one. Switching context is how you change which daemon a `docker` command operates against, without restarting anything.
 
 6. Show the currently used context.
 ```
@@ -116,7 +116,7 @@ docker build -f Dockerfile.slim -t node-slim .
 docker images | grep node-
 ```
 
-> The slim image should be significantly smaller. This demonstrates the trade-off: slim images save space but may be missing tools you need for debugging.
+> The slim image should be significantly smaller. There's a trade-off here: slim images strip out common debugging tools (`curl`, `vim`, sometimes even most of a shell), so when something breaks in production you may not have your usual diagnostic kit available. For even smaller images, look at **Alpine** (5–10MB base, swaps glibc for musl) or **distroless** images from Google (no shell at all — just your binary and its runtime). Each step down trades convenience for less storage cost, faster pulls, and a smaller attack surface.
 
 4. Clean up.
 ```

--- a/public/06-docker-compose.md
+++ b/public/06-docker-compose.md
@@ -16,6 +16,8 @@
 
 ## B. Docker Compose Basics
 
+> A `docker-compose.yml` file is a declarative description of a multi-container app. The top-level **services** key lists each container, and each service entry is roughly equivalent to a `docker run` invocation — only with the flags spread across structured fields (`build`, `image`, `ports`, `environment`, `depends_on`). When you `docker compose up`, Compose also creates a default network and attaches every service to it, and crucially uses each service's **name** as its DNS hostname on that network. That's how `web` will reach `redis` in the example below without any IP addresses or port mappings between them.
+
 1. Verify Docker Compose is installed.
 ```
 docker compose version
@@ -105,6 +107,8 @@ curl http://localhost:5000
 
 > Each request should increment the counter, demonstrating that the Flask app is communicating with Redis.
 
+> Notice that `app.py` connects to Redis using the literal hostname `redis` (set via `REDIS_HOST` in the compose file). It works because Compose attached both containers to a default network and used the service names as DNS names. There's no port mapping for Redis in `docker-compose.yml` and there doesn't need to be — `web` reaches it over the internal network, not through the host.
+
 10. View the logs from all services.
 ```
 docker compose logs
@@ -117,7 +121,7 @@ docker compose down
 
 ## C. Working with Databases in Development
 
-> Docker Compose is excellent for running databases alongside your application during development.
+> Docker Compose is excellent for running databases alongside your application during development — a fresh, isolated database per project, brought up and torn down with one command. The interesting bit in the example below is the **`depends_on` + `condition: service_healthy`** combination. Plain `depends_on` only waits for a container to *start*; it doesn't wait for the service inside to actually accept connections. Web apps that fail with "connection refused" right at startup are usually missing exactly this. The `healthcheck` block plus the `service_healthy` condition gates `web`'s startup on a real readiness probe (`pg_isready`) instead.
 
 1. Create a new project directory.
 ```
@@ -234,7 +238,7 @@ docker compose down -v
 
 ## D. Using .env Files
 
-> Environment files allow you to externalize configuration without modifying the compose file.
+> Compose handles environment variables in two distinct (and easy-to-confuse) ways. **Variable substitution** uses `${VAR}` syntax inside `docker-compose.yml` itself, with values pulled from a local `.env` file or your shell — these get substituted *before* the compose file is parsed. **Container environment variables** (the `environment:` key in a service) are passed *into* the running container at runtime. The example below uses both: `${APP_PORT}` is substituted into the port mapping by Compose at parse time, while `DEBUG=${DEBUG}` is passed as an environment variable that the app inside the container can read.
 
 1. Create a new directory.
 ```
@@ -284,7 +288,7 @@ docker compose down
 
 ## E. Development vs Production Configurations
 
-> Docker Compose supports multiple configuration files for different environments.
+> A common pattern is to keep one **base** `docker-compose.yml` with the shared service definitions and add **override files** (`docker-compose.dev.yml`, `docker-compose.prod.yml`) that layer environment-specific changes on top. When you pass multiple `-f` flags, Compose merges the files in order, with later files overriding earlier ones field by field. This avoids duplicating the entire compose file just to change a few environment variables, volume mounts, or replica counts.
 
 1. Create a base compose file.
 ```

--- a/public/07-docker-ci-security.md
+++ b/public/07-docker-ci-security.md
@@ -2,7 +2,7 @@
 
 ## A. Building a CI Pipeline for Docker Images
 
-> A CI pipeline for Docker typically includes: building images, running tests, scanning for vulnerabilities, and pushing to a registry.
+> A CI pipeline for Docker typically chains four stages: **test** (unit and integration tests against the source), **build** (assemble the image), **scan** (check for known vulnerabilities), and **push** (publish to a registry). The whole point of running them in this order — gated by `needs:` in GitHub Actions, `requires:` in CircleCI, or `dependencies:` in GitLab — is to prevent broken or vulnerable images from ever reaching the registry. If `scan` finds a critical CVE, `push` never runs.
 
 ### GitHub Actions CI Pipeline Example
 
@@ -145,7 +145,7 @@ EOF
 
 ## B. Security Scanning with Trivy
 
-> Trivy is a comprehensive security scanner for containers. It detects vulnerabilities in OS packages and application dependencies.
+> **Trivy** is an open-source vulnerability scanner that compares the packages installed in your image against public **CVE databases** (NVD, vendor advisories, GitHub's database, and others) — those databases list every publicly-disclosed vulnerability with a severity rating. Running Trivy in CI lets you catch a vulnerable dependency *before* it reaches production, rather than discovering it from a Slack alert at 3 AM. The `--exit-code 1` flag is what turns Trivy into a **CI gate**: a non-zero exit fails the job, which (via `needs:`) blocks the push step.
 
 1. Install Trivy (if not using GitHub Actions).
 ```
@@ -177,7 +177,7 @@ trivy image --exit-code 1 --severity CRITICAL nginx:latest
 
 ## C. Docker Scout for Vulnerability Detection
 
-> Docker Scout is Docker's native security scanning tool integrated into Docker Desktop and CLI.
+> **Docker Scout** is Docker's first-party scanner, integrated directly into Docker Desktop and the CLI. Functionally it overlaps with Trivy: both query CVE databases against your image's package list. The practical difference is ecosystem — Scout is convenient if you're already on Docker Desktop, while Trivy is the de-facto open-source standard and works equally well outside it (in CI, against non-Docker registries, against filesystems and Kubernetes manifests). Most teams pick one; some run both for defense in depth.
 
 1. Enable Docker Scout (Docker Desktop users).
 ```
@@ -195,6 +195,8 @@ docker scout compare nginx:latest nginx:1.24-alpine
 ```
 
 ## D. Dockerfile Security Best Practices
+
+> Three of the highest-leverage hardening practices: **pin specific base image versions** (so a `latest` tag floating to a compromised build can't poison your image overnight), **run as a non-root user** (so a process escape doesn't immediately get container-root capabilities), and **use multi-stage builds** (so the build toolchain and source code don't ship to production along with the binary). The examples below show each.
 
 ### Use Specific Base Image Versions
 ```
@@ -249,7 +251,7 @@ docker run --rm -i hadolint/hadolint < Dockerfile.secure #or Dockerfile.multista
 
 ## E. Using .dockerignore
 
-> Prevent sensitive files from being included in the image.
+> The `.dockerignore` file does for `docker build` what `.gitignore` does for `git`: it excludes files from the **build context** sent to the Docker daemon. There are two reasons to care. First, **secrets hygiene** — keep `.env`, credentials, and key files out of the image entirely, since image layers are recoverable forever. Second, **build speed** — smaller contexts upload faster, and excluding `node_modules` or `__pycache__` can cut a multi-gigabyte transfer to a few megabytes.
 
 1. Create a .dockerignore file.
 ```
@@ -285,7 +287,7 @@ EOF
 
 ## F. Secrets Management in Docker
 
-> Never store secrets in Docker images. Use runtime secrets instead.
+> The cardinal rule: **never bake secrets into image layers**. Layers are content-addressed and cached — once a secret is in a layer, it's recoverable from the image even if a later `RUN rm` "deletes" it, and anyone who pulls the image gets a copy. The patterns below show three safer alternatives: Docker Swarm secrets (mounted as files under `/run/secrets/...` at runtime), runtime environment variables, and **BuildKit build secrets** (which mount a secret into a single `RUN` step without persisting it to any layer).
 
 ### Using Docker Secrets (Swarm Mode)
 ```
@@ -317,7 +319,7 @@ docker build --secret id=pip_token,src=./pip_token.txt -t myapp .
 
 ## G. Image Signing and Verification
 
-> Docker Content Trust enables image signing and verification.
+> Image signing answers the question, "is this image actually the one the maintainer published, or was it tampered with along the way?" **Docker Content Trust** (DCT) is Docker's original implementation, based on Notary v1. Most modern signing workflows have moved to **Sigstore / cosign**, which integrates with OIDC identities and a public transparency log (Rekor) — but DCT is still supported and is what's wired into the `docker push` command directly, so it remains a useful reference point.
 
 1. Enable Docker Content Trust.
 ```


### PR DESCRIPTION
## Summary
- Adds interspersed teaching content (section intros and conceptual `> ` callouts) to labs 2–7 to match the explanatory style established in lab 1.
- Every command, code block, and step number is preserved byte-identical to `main` — verified by filtering the diff for non-blockquote changes (empty result) and confirming fenced-block counts are unchanged in every file.
- Topics expanded include: writable layer vs. image layers, union filesystem, Dockerfile caching, multi-stage build motivation, registry/access-token model, Linux namespaces behind isolation, default-bridge vs. custom-bridge DNS, 12-factor config, named volumes vs. bind mounts, `unless-stopped` vs. `always`, network drivers, port publishing vs. linking, overlay networks, Docker contexts, slim/Alpine/distroless trade-offs, Compose service-name DNS, `depends_on` + `service_healthy`, variable substitution vs. container env, override-file merging, CI pipeline gating, CVE databases, Trivy vs. Scout, Dockerfile hardening, `.dockerignore` size impact, secrets-in-layers risk, DCT vs. sigstore.

## Test plan
- [ ] Render each modified `public/0[2-7]-*.md` in GitHub's markdown preview and confirm blockquote callouts appear cleanly with no broken code fences
- [ ] Run `git diff main -- public/ | grep -E '^[+-]' | grep -vE '^[+-]>' | grep -vE '^[+-]\s*$' | grep -vE '^(---|\+\+\+)'` and confirm output is empty (no command lines changed)
- [ ] Walk through at least one lab end-to-end on a Linux host to confirm the new prose reads naturally between steps